### PR TITLE
Sugerencia counting_nucleotides.py

### DIFF
--- a/src/counting_nucleotides.py
+++ b/src/counting_nucleotides.py
@@ -15,8 +15,7 @@ CATEGORY
 DNA sequence
 
 USAGE
-El programa permite obtener la frecuencia de aparicion de cada uno de los cuatro nucleotidos
-en una secuencia de DNA. Esta secuencia debe de ser introducida por el usuario.
+python count_nucleotides.py
 
 ARGUMENTS
 None
@@ -25,8 +24,17 @@ SEE ALSO
 None
 '''
 
-# Pedimos la secuencia de DNA al usuario
-dna = input("Introduzca una secuencia de DNA: \n")
+# Obtener la secuencia de ADN del usuario
+dna= input("Introduzca una secuencia de DNA:\n")
 
-# Contamos la cantidad de nucleótidos que hay en la secuencia y lo imprimimos al usuario
-print(f"La cantidad de A es: {dna.count('A')}. \nLa cantidad de T es: {dna.count('T')}. \nLa cantidad de C es: {dna.count('C')}. \nLa cantidad de G es: {dna.count('G')}.")
+# Realizar conteo de cada base
+freq_A = dna.count('A')
+freq_C = dna.count('C')
+freq_G = dna.count('G')
+freq_T = dna.count('T')
+
+# Imprimir el resultado
+print(f"""La cantidad de A es: {freq_A}
+La cantidad de C es: {freq_C}  
+La cantidad de G es: {freq_G}  
+La cantidad de T es: {freq_T}""")


### PR DESCRIPTION
Evita las lineas muy largas. En el caso del print pudiste haber hecho un bloque para la asignación de variables y que de este modo se redujera su tamaño. Fuera de eso, la lógica que empleaste esta perfecta :)